### PR TITLE
update lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,4 +41,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   1.17.2
+   2.2.15


### PR DESCRIPTION
ruby:latest image では ruby 3 が 降ってくるようになっており bundler が 2であるため以下のようなエラーが出る
```
/usr/local/lib/ruby/3.0.0/rubygems.rb:281:in `find_spec_for_exe': Could not find 'bundler' (1.17.2) required by your /pkg/Gemfile.lock. (Gem::GemNotFoundException)
To update to the latest version installed on your system, run `bundle update --bundler`.
To install the missing version, run `gem install bundler:1.17.2`
	from /usr/local/lib/ruby/3.0.0/rubygems.rb:300:in `activate_bin_path'
	from /usr/local/bin/bundle:23:in `<main>'
```

それを解消する