### PR TITLE
講義の関係上 ruby 2.6.2 bundler 1.17.2 とする

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3,7 +3,7 @@ name: default
 
 steps:
   - name: test
-    image: ruby
+    image: ruby:2.6.2
     commands:
       - bundle install
       - rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,4 +41,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   2.2.15
+   1.17.2


### PR DESCRIPTION
#2 で更新してもらった矢先申し訳ないのですが、 講義の関係上 一旦 ruby 2.6.2 ですすめるため bundler のバージョンを落とします。
drone-exercise-rails とあわせてruby のバージョンは今後更新が必要です。